### PR TITLE
Fix exception when installing collection

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ description: Spatium Cepa TrueNAS Management Ansible Collection
 readme: "README.md"
 authors:
   - Nicholas Kiraly (@nkiraly)
-dependencies: []
+dependencies: {}
 license:
   - "BSD-2-Clause"
 tags:


### PR DESCRIPTION
#### Changes
- Make "dependencies" variable in galaxy.yml to an empty dict

#### Risks
- N/A

#### Testing
- Ran ansible-galaxy collection install with ansible 2.12.1

According to the [docs](https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html#structure), the dependencies variable may be omitted, that could be an alternate solution.